### PR TITLE
날짜 저장 포맷 바꾸기

### DIFF
--- a/src/main/java/com/gxdxx/programadmin/dto/CommentListDto.java
+++ b/src/main/java/com/gxdxx/programadmin/dto/CommentListDto.java
@@ -3,6 +3,7 @@ package com.gxdxx.programadmin.dto;
 import lombok.*;
 
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 
 @Getter
 @Setter
@@ -17,7 +18,7 @@ public class CommentListDto {
 
     private String createdBy;
 
-    private LocalDateTime createdAt;
+    private String createdAt;
 
     @Builder
     public CommentListDto(Long id, Long postId, String content, String createdBy, LocalDateTime createdAt) {
@@ -25,7 +26,7 @@ public class CommentListDto {
         this.postId = postId;
         this.content = content;
         this.createdBy = createdBy;
-        this.createdAt = createdAt;
+        this.createdAt = createdAt.format(DateTimeFormatter.ofPattern("yyyy/MM/dd hh:mm:ss"));
     }
 
 }

--- a/src/main/java/com/gxdxx/programadmin/dto/PostDetailDto.java
+++ b/src/main/java/com/gxdxx/programadmin/dto/PostDetailDto.java
@@ -3,6 +3,7 @@ package com.gxdxx.programadmin.dto;
 import lombok.*;
 
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 
 @Getter
 @Setter
@@ -19,7 +20,7 @@ public class PostDetailDto {
 
     private String createdBy;
 
-    private LocalDateTime createdAt;
+    private String createdAt;
 
     @Builder
     public PostDetailDto(Long id, String title, String content, String hashtag, String createdBy, LocalDateTime createdAt) {
@@ -28,7 +29,7 @@ public class PostDetailDto {
         this.content = content;
         this.hashtag = hashtag;
         this.createdBy = createdBy;
-        this.createdAt = createdAt;
+        this.createdAt = createdAt.format(DateTimeFormatter.ofPattern("yyyy/MM/dd hh:mm:ss"));
     }
 
 

--- a/src/main/java/com/gxdxx/programadmin/dto/PostListDto.java
+++ b/src/main/java/com/gxdxx/programadmin/dto/PostListDto.java
@@ -5,8 +5,10 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
+import org.springframework.format.annotation.DateTimeFormat;
 
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 
 @Getter
 @Setter
@@ -25,14 +27,18 @@ public class PostListDto {
 
     private String createdBy;
 
-    private LocalDateTime createdAt;
-
-    public static PostListDto of(Long id, String memberName, String title, String content, String hashtag, String createdBy, LocalDateTime createdAt) {
-        return new PostListDto(id, memberName, title, content, hashtag, createdBy, createdAt);
-    }
+    private String createdAt;
 
     public static PostListDto from(Post post) {
-        return new PostListDto(post.getId(), post.getMember().getMemberName(), post.getTitle(), post.getContent(), post.getHashtag(), post.getCreatedBy(), post.getCreatedAt());
+        return new PostListDto(
+                post.getId(),
+                post.getMember().getMemberName(),
+                post.getTitle(),
+                post.getContent(),
+                post.getHashtag(),
+                post.getCreatedBy(),
+                post.getCreatedAt().format(DateTimeFormatter.ofPattern("yyyy/MM/dd hh:mm:ss"))
+        );
     }
 
 }

--- a/src/main/java/com/gxdxx/programadmin/entity/Auditing.java
+++ b/src/main/java/com/gxdxx/programadmin/entity/Auditing.java
@@ -18,7 +18,7 @@ import java.time.LocalDateTime;
 @ToString
 @EntityListeners(AuditingEntityListener.class)
 @MappedSuperclass
-public class Auditing {
+public abstract class Auditing {
 
     @CreatedBy
     @Column(nullable = false, updatable = false, length = 30)


### PR DESCRIPTION
DB에 저장할 때 createdAt와 modifiedAt을 밀리초까지 저장하고,
화면에 보여줄 때도 그대로 보여주다 보니 불필요한 값까지 나타나는 문제가 있었다.

DB에 저장할 때는 @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) 으로 밀리초까지 저장되게 하고,
화면에 보여줄 때는 DTO에서 yyyy/MM/dd hh:mm:ss 포맷을 적용해 간단하게 보이도록 수정했다. 

This closes #29 